### PR TITLE
Update FUNDING.yml

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: https://openssl-foundation.org/sponsor/index.html
+custom: https://openssl-foundation.org/sponsorship/


### PR DESCRIPTION
The existing link is incorrect.
~~I was considering https://openssl-foundation.org/sponsorship/ (which is correct, but not very githuby), but thought that for github, the github sponsorship is probably what most want to reach, so save them a click.~~